### PR TITLE
Reference declaration file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "dist/react-lazy-images.es.js",
   "main": "dist/react-lazy-images.js",
   "umd:main": "dist/react-lazy-images.umd.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "dev": "npm-run-all --parallel bundle:dev storybook",
     "build": "npm-run-all bundle:prod size",


### PR DESCRIPTION
I thought that TS automatically finds the declaration file it is next to the main entry. Guess not :grin: 