### PR TITLE
Pass back img attributes in render callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ The presentation can be derived from those plus, crucially, any specific needs y
 | **render**        | Function of type ({src, alt, srcSet, imageState}) => React.ReactNode |                                           | true (or `children`) | Function to call that renders based on the props and state provided to it by LazyImageFull            |
 | **children**      | Function of type ({src, alt, srcSet, imageState}) => React.ReactNode |                                           | true (or `render`)   | Function to call that renders based on the props and state provided to it by LazyImageFull            |
 
-[You can consult Typescript types in the code](./src/LazyImage.tsx) as a more exact definition.
+[You can consult Typescript types in the code](./src/LazyImage.tsx) for more context.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -106,20 +106,24 @@ import { LazyImage } from "react-lazy-images";
 
 <LazyImage
   src="/img/porto_buildings_large.jpg"
-  placeholder={() => (
+  alt="Buildings with tiled exteriors, lit by the sunset."
+  placeholder={({alt}) => (
     <img
       src="/img/porto_buildings_lowres.jpg"
-      alt="Buildings with tiled exteriors, lit by the sunset."
+      alt={alt}
     />
   )}
-  actual={() => (
+  actual={({src, alt, srcSet}) => (
     <img
-      src="/img/porto_buildings_large.jpg"
-      alt="Buildings with tiled exteriors, lit by the sunset."
+      src={src}
+      alt={alt}
     />
   )}
 />;
 ```
+
+Note that while you can set the rendered components to be anything you want, you most likely want to use the same `src`, `srcSet` and `alt` attributes in an `<img>` eventually.
+To keep this consistent, and reduce repetition, the render callbacks pass those attributes back to you.
 
 [You can play around with this library on Codesandbox](https://codesandbox.io/s/jnn9wjkj1w).
 
@@ -140,30 +144,34 @@ Thus, whether you want to display a simple `<img>`, your own `<Image>`, or even 
 ```jsx
 <LazyImage
   src="/img/porto_buildings_large.jpg"
-  // This is rendered first
+  alt="Buildings with tiled exteriors, lit by the sunset."
+
+  // This is rendered first, notice how the src is different
   placeholder={
-    () =>
-      <img src="/img/porto_buildings_lowres.jpg" alt="Buildings with tiled exteriors, lit by the sunset." />
+    ({alt}) =>
+      <img src="/img/porto_buildings_lowres.jpg" alt={alt} />
   }
-  // This is rendered once in view
+  // This is rendered once in view; we use the src and alt above for consistency
   actual={
-    () =>
-      <img src="/img/porto_buildings_large.jpg" alt="Buildings with tiled exteriors, lit by the sunset." />
+    ({src, alt}) =>
+      <img src={src} alt={alt} />
   }
 />
 
 // Perhaps you want a container?
 <LazyImage
+  src="/img/porto_buildings_lowres.jpg"
+  alt="Buildings with tiled exteriors, lit by the sunset."
   placeholder={
-    () =>
+    ({src, alt}) =>
       <div className={`LazyImage-Placeholder`}">
-        <img src="/img/porto_buildings_lowres.jpg" alt="Buildings with tiled exteriors, lit by the sunset." />
+        <img  />
       </div>
   }
   actual={
-    () =>
+    ({src, alt}) =>
       <div className={`LazyImage-Actual`}>
-        <img src="/img/porto_buildings_large.jpg" alt="Buildings with tiled exteriors, lit by the sunset." />
+        <img src={src} alt={alt} />
       </div>
   }
 />
@@ -183,11 +191,11 @@ import {LazyImageFull, ImageState} from 'react-lazy-images';
 // Function as child
 // `src` and `srcSet` are passed back to the render callback for convenience/consistency
 <LazyImageFull src='/img/porto_buildings_large.jpg'>
-  {({src, srcSet, imageState}) =>
+  {({src, alt, srcSet, imageState}) =>
     <img
       src={imageState === ImageState.LoadSuccess ? src : '/img/porto_buildings_lowres.jpg'}
+      alt={alt}
       style={{opacity: ImageState.LoadSuccess ? '1' : '0.5'}}
-      alt="Buildings with tiled exteriors, lit by the sunset." />
     />
   }
 </LazyImageFull>
@@ -195,11 +203,11 @@ import {LazyImageFull, ImageState} from 'react-lazy-images';
 // render prop
 <LazyImageFull
   src='/img/porto_buildings_large.jpg'
-  render={({src, srcSet, imageState}) =>
+  render={({src, alt, srcSet, imageState}) =>
     <img
       src={imageState === ImageState.LoadSuccess ? src : '/img/porto_buildings_lowres.jpg'}
+      alt={alt}
       style={{opacity: ImageState.LoadSuccess ? '1' : '0.5'}}
-      alt="Buildings with tiled exteriors, lit by the sunset." />
     />
   }
 />
@@ -228,16 +236,17 @@ This behaviour is provided with the `src` prop:
 // so that the image can be requested before rendering
 <LazyImage
   src="/img/porto_buildings_large.jpg"
+  alt="Buildings with tiled exteriors, lit by the sunset."
   placeholder={
-    () =>
+    ({alt}) =>
       <div className={`LazyImage-Placeholder`}">
-        <img src="/img/porto_buildings_lowres.jpg" alt="Buildings with tiled exteriors, lit by the sunset." />
+        <img src="/img/porto_buildings_lowres.jpg" alt={alt} />
       </div>
   }
   actual={
-    () =>
+    ({src, alt}) =>
       <div className={`LazyImage-Actual`}>
-        <img src="/img/porto_buildings_large.jpg" alt="Buildings with tiled exteriors, lit by the sunset." />
+        <img src={src} alt={alt} />
       </div>
   }
 />
@@ -252,11 +261,12 @@ You can choose what to display on Loading and Error using the render props `load
 ```jsx
 <div className="bg-light-silver h5 w-100">
   <LazyImage
-    src="https://www.fillmurray.com/notanimage"
-    actual={() => (
+    src="/image/brokenimagenotherewhoops.jpg"
+    alt="Buildings with tiled exteriors, lit by the sunset."
+    actual={({src, alt}) => (
       <img
-        src="/img/porto_buildings_large.jpg"
-        alt="Buildings with tiled exteriors, lit by the sunset."
+        src={src}
+        alt={alt}
       />
     )}
     loading={() => (
@@ -288,16 +298,17 @@ This behaviour is available by using a `loadEagerly` prop:
 <LazyImage
   loadEagerly
   src="/img/porto_buildings_large.jpg"
-  placeholder={() => (
+  alt="Buildings with tiled exteriors, lit by the sunset."
+  placeholder={({alt}) => (
     <img
       src="/img/porto_buildings_lowres.jpg"
-      alt="Buildings with tiled exteriors, lit by the sunset."
+      alt={alt}
     />
   )}
-  actual={() => (
+  actual={({src, alt}) => (
     <img
-      src="/img/porto_buildings_large.jpg"
-      alt="Buildings with tiled exteriors, lit by the sunset."
+      src={src}
+      alt={alt}
     />
   )}
 />
@@ -414,6 +425,13 @@ Read the notes section either on Storybook or the story source if you are wonder
 [The starter on Codesandbox](https://codesandbox.io/s/jnn9wjkj1w) has a good basis for two popular presentational patterns.
 In particular, it shows intrinsic placeholders and fading in the actual image.
 
+You might be thinking that this library has a lot of wiring exposed.
+This is very much intended.
+If this library were to provide presentational patterns out of the box, then it would lead to many issues and PRs about what ultimately is opinion.
+Being inclined to fork a library just to add a prop is not a nice situation to be in, compared to writing one abstracted component for your specific use case.
+The behaviour and loading patterns are configurable, because those are what this library is about.
+The presentation can be derived from those, plus, crucially, any specific needs your application has.
+
 ## API Reference
 
 **`<LazyImage />`** accepts the following props:
@@ -421,26 +439,28 @@ In particular, it shows intrinsic placeholders and fading in the actual image.
 | Name              | Type                                    | Default                                   | Required | Description                                                                                           |
 | ----------------- | --------------------------------------- | ----------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
 | **src**           | String                                  |                                           | true     | The source of the image to load                                                                       |
+| **alt**           | String                                                          |                                           | false                | The alt text description of the image you are loading                                                                       |
 | **srcSet**        | String                                  |                                           | false    | If your images use srcset, you can pass the `srcSet` prop to provide that information for preloading. |
-| **actual**        | Function (render prop)                  |                                           | true     | Component to display once image has loaded                                                            |
-| **placeholder**   | Function (render prop)                  | undefined                                 | false    | Component to display while no request for the actual image has been made                              |
-| **loading**       | Function (render prop)                  | placeholder                               | false    | Component to display while the image is loading                                                       |
-| **error**         | Function (render prop)                  | actual (broken image)                     | false    | Component to display if the image loading has failed (render prop)                                    |
+| **actual**        | Function (render callback) of type ({src, alt, srcSet}) => React.ReactNode                 |                                           | true     | Component to display once image has loaded                                                            |
+| **placeholder**   | Function (render callback) of type ({alt}) => React.ReactNode                 | undefined                                 | false    | Component to display while no request for the actual image has been made                              |
+| **loading**       | Function (render callback) of type () => React.ReactNode                 | placeholder                               | false    | Component to display while the image is loading                                                       |
+| **error**         | Function (render callback) of type () => React.ReactNode                | actual (broken image)                     | false    | Component to display if the image loading has failed (render prop)                                    |
 | **loadEagerly**   | Boolean                                 | false                                     | false    | Whether to skip checking for viewport and always show the 'actual' component                          |
 | **observerProps** | {threshold: number, rootMargin: string} | {threshold: 0.01, rootMargin: "50px 0px"} | false    | Subset of props for the IntersectionObserver                                                          |
-
-[You can consult Typescript types in the code](./src/LazyImage.tsx) as a more exact definition.
 
 **`<LazyImageFull />`** accepts the following props:
 
 | Name              | Type                                                            | Default                                   | Required             | Description                                                                                           |
 | ----------------- | --------------------------------------------------------------- | ----------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
 | **src**           | String                                                          |                                           | true                 | The source of the image to load                                                                       |
+| **alt**           | String                                                          |                                           | false                | The alt text description of the image you are loading                                                                       |
 | **srcSet**        | String                                                          |                                           | false                | If your images use srcset, you can pass the `srcSet` prop to provide that information for preloading. |
 | **loadEagerly**   | Boolean                                                         | false                                     | false                | Whether to skip checking for viewport and always show the 'actual' component                          |
 | **observerProps** | {threshold: number, rootMargin: string}                         | {threshold: 0.01, rootMargin: "50px 0px"} | false                | Subset of props for the IntersectionObserver                                                          |
-| **render**        | Function of type ({src, srcSet, imageState}) => React.ReactNode |                                           | true (or `children`) | Function to call that renders based on the props and state provided to it by LazyImageFull            |
-| **children**      | Function of type ({src, srcSet, imageState}) => React.ReactNode |                                           | true (or `render`)   | Function to call that renders based on the props and state provided to it by LazyImageFull            |
+| **render**        | Function of type ({src, alt, srcSet, imageState}) => React.ReactNode |                                           | true (or `children`) | Function to call that renders based on the props and state provided to it by LazyImageFull            |
+| **children**      | Function of type ({src, alt, srcSet, imageState}) => React.ReactNode |                                           | true (or `render`)   | Function to call that renders based on the props and state provided to it by LazyImageFull            |
+
+[You can consult Typescript types in the code](./src/LazyImage.tsx) as a more exact definition.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -107,18 +107,10 @@ import { LazyImage } from "react-lazy-images";
 <LazyImage
   src="/img/porto_buildings_large.jpg"
   alt="Buildings with tiled exteriors, lit by the sunset."
-  placeholder={({alt}) => (
-    <img
-      src="/img/porto_buildings_lowres.jpg"
-      alt={alt}
-    />
+  placeholder={({ alt }) => (
+    <img src="/img/porto_buildings_lowres.jpg" alt={alt} />
   )}
-  actual={({src, alt, srcSet}) => (
-    <img
-      src={src}
-      alt={alt}
-    />
-  )}
+  actual={({ src, alt, srcSet }) => <img src={src} alt={alt} />}
 />;
 ```
 
@@ -160,17 +152,17 @@ Thus, whether you want to display a simple `<img>`, your own `<Image>`, or even 
 
 // Perhaps you want a container?
 <LazyImage
-  src="/img/porto_buildings_lowres.jpg"
+  src="/img/porto_buildings_large.jpg"
   alt="Buildings with tiled exteriors, lit by the sunset."
   placeholder={
-    ({src, alt}) =>
-      <div className={`LazyImage-Placeholder`}">
-        <img  />
+    ({alt}) =>
+      <div className={'LazyImage-Placeholder'}">
+        <img src="/img/porto_buildings_lowres.jpg" alt={alt} />
       </div>
   }
   actual={
     ({src, alt}) =>
-      <div className={`LazyImage-Actual`}>
+      <div className={'LazyImage-Actual'}>
         <img src={src} alt={alt} />
       </div>
   }
@@ -189,7 +181,7 @@ In those cases, consider `LazyImageFull`:
 import {LazyImageFull, ImageState} from 'react-lazy-images';
 
 // Function as child
-// `src` and `srcSet` are passed back to the render callback for convenience/consistency
+// `src`, `alt` and `srcSet` are passed back to the render callback for convenience/consistency
 <LazyImageFull src='/img/porto_buildings_large.jpg'>
   {({src, alt, srcSet, imageState}) =>
     <img
@@ -263,12 +255,7 @@ You can choose what to display on Loading and Error using the render props `load
   <LazyImage
     src="/image/brokenimagenotherewhoops.jpg"
     alt="Buildings with tiled exteriors, lit by the sunset."
-    actual={({src, alt}) => (
-      <img
-        src={src}
-        alt={alt}
-      />
-    )}
+    actual={({ src, alt }) => <img src={src} alt={alt} />}
     loading={() => (
       <div>
         <p className="pa3 f5 lh-copy near-white">Loading...</p>
@@ -299,18 +286,10 @@ This behaviour is available by using a `loadEagerly` prop:
   loadEagerly
   src="/img/porto_buildings_large.jpg"
   alt="Buildings with tiled exteriors, lit by the sunset."
-  placeholder={({alt}) => (
-    <img
-      src="/img/porto_buildings_lowres.jpg"
-      alt={alt}
-    />
+  placeholder={({ alt }) => (
+    <img src="/img/porto_buildings_lowres.jpg" alt={alt} />
   )}
-  actual={({src, alt}) => (
-    <img
-      src={src}
-      alt={alt}
-    />
-  )}
+  actual={({ src, alt }) => <img src={src} alt={alt} />}
 />
 ```
 
@@ -361,7 +340,7 @@ I also think that using the server method, albeit safe, would be messy with some
 
 **Silver lining:**
 
-There is generally no case where `<noscript>` will be rendered by client-side react. 
+There is generally no case where `<noscript>` will be rendered by client-side react.
 This means that, if you are in charge of server-rendering and you trust your bundling setup, then you can have this fallback!
 Look at [`src/fallbackUtils.tsx`](./src/fallbackUtils.tsx) for a function that can work.
 You would probably do something like this:
@@ -369,6 +348,7 @@ You would probably do something like this:
 ```jsx
 <LazyImage
   src="actualImgSrc"
+  alt="alt description here"
   placeholder={//the usual}
   actual={//the usual}
 />
@@ -430,33 +410,33 @@ This is very much intended.
 If this library were to provide presentational patterns out of the box, then it would lead to many issues and PRs about what ultimately is opinion.
 Being inclined to fork a library just to add a prop is not a nice situation to be in, compared to writing one abstracted component for your specific use case.
 The behaviour and loading patterns are configurable, because those are what this library is about.
-The presentation can be derived from those, plus, crucially, any specific needs your application has.
+The presentation can be derived from those plus, crucially, any specific needs your application has.
 
 ## API Reference
 
 **`<LazyImage />`** accepts the following props:
 
-| Name              | Type                                    | Default                                   | Required | Description                                                                                           |
-| ----------------- | --------------------------------------- | ----------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| **src**           | String                                  |                                           | true     | The source of the image to load                                                                       |
-| **alt**           | String                                                          |                                           | false                | The alt text description of the image you are loading                                                                       |
-| **srcSet**        | String                                  |                                           | false    | If your images use srcset, you can pass the `srcSet` prop to provide that information for preloading. |
-| **actual**        | Function (render callback) of type ({src, alt, srcSet}) => React.ReactNode                 |                                           | true     | Component to display once image has loaded                                                            |
-| **placeholder**   | Function (render callback) of type ({alt}) => React.ReactNode                 | undefined                                 | false    | Component to display while no request for the actual image has been made                              |
-| **loading**       | Function (render callback) of type () => React.ReactNode                 | placeholder                               | false    | Component to display while the image is loading                                                       |
-| **error**         | Function (render callback) of type () => React.ReactNode                | actual (broken image)                     | false    | Component to display if the image loading has failed (render prop)                                    |
-| **loadEagerly**   | Boolean                                 | false                                     | false    | Whether to skip checking for viewport and always show the 'actual' component                          |
-| **observerProps** | {threshold: number, rootMargin: string} | {threshold: 0.01, rootMargin: "50px 0px"} | false    | Subset of props for the IntersectionObserver                                                          |
+| Name              | Type                                                                       | Default                                   | Required | Description                                                                                           |
+| ----------------- | -------------------------------------------------------------------------- | ----------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| **src**           | String                                                                     |                                           | true     | The source of the image to load                                                                       |
+| **alt**           | String                                                                     |                                           | false    | The alt text description of the image you are loading                                                 |
+| **srcSet**        | String                                                                     |                                           | false    | If your images use srcset, you can pass the `srcSet` prop to provide that information for preloading. |
+| **actual**        | Function (render callback) of type ({src, alt, srcSet}) => React.ReactNode |                                           | true     | Component to display once image has loaded                                                            |
+| **placeholder**   | Function (render callback) of type ({alt}) => React.ReactNode              | undefined                                 | false    | Component to display while no request for the actual image has been made                              |
+| **loading**       | Function (render callback) of type () => React.ReactNode                   | placeholder                               | false    | Component to display while the image is loading                                                       |
+| **error**         | Function (render callback) of type () => React.ReactNode                   | actual (broken image)                     | false    | Component to display if the image loading has failed (render prop)                                    |
+| **loadEagerly**   | Boolean                                                                    | false                                     | false    | Whether to skip checking for viewport and always show the 'actual' component                          |
+| **observerProps** | {threshold: number, rootMargin: string}                                    | {threshold: 0.01, rootMargin: "50px 0px"} | false    | Subset of props for the IntersectionObserver                                                          |
 
 **`<LazyImageFull />`** accepts the following props:
 
-| Name              | Type                                                            | Default                                   | Required             | Description                                                                                           |
-| ----------------- | --------------------------------------------------------------- | ----------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
-| **src**           | String                                                          |                                           | true                 | The source of the image to load                                                                       |
-| **alt**           | String                                                          |                                           | false                | The alt text description of the image you are loading                                                                       |
-| **srcSet**        | String                                                          |                                           | false                | If your images use srcset, you can pass the `srcSet` prop to provide that information for preloading. |
-| **loadEagerly**   | Boolean                                                         | false                                     | false                | Whether to skip checking for viewport and always show the 'actual' component                          |
-| **observerProps** | {threshold: number, rootMargin: string}                         | {threshold: 0.01, rootMargin: "50px 0px"} | false                | Subset of props for the IntersectionObserver                                                          |
+| Name              | Type                                                                 | Default                                   | Required             | Description                                                                                           |
+| ----------------- | -------------------------------------------------------------------- | ----------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------- |
+| **src**           | String                                                               |                                           | true                 | The source of the image to load                                                                       |
+| **alt**           | String                                                               |                                           | false                | The alt text description of the image you are loading                                                 |
+| **srcSet**        | String                                                               |                                           | false                | If your images use srcset, you can pass the `srcSet` prop to provide that information for preloading. |
+| **loadEagerly**   | Boolean                                                              | false                                     | false                | Whether to skip checking for viewport and always show the 'actual' component                          |
+| **observerProps** | {threshold: number, rootMargin: string}                              | {threshold: 0.01, rootMargin: "50px 0px"} | false                | Subset of props for the IntersectionObserver                                                          |
 | **render**        | Function of type ({src, alt, srcSet, imageState}) => React.ReactNode |                                           | true (or `children`) | Function to call that renders based on the props and state provided to it by LazyImageFull            |
 | **children**      | Function of type ({src, alt, srcSet, imageState}) => React.ReactNode |                                           | true (or `render`)   | Function to call that renders based on the props and state provided to it by LazyImageFull            |
 
@@ -475,18 +455,19 @@ See [`ROADMAP.md`](./ROADMAP.md) for information and ideas about where the proje
 I would love to have contributions on this! Are there more patterns that we can expose and simplify? Is something not clear? See `CONTRIBUTING.md` for details.
 
 ## Thanks and Inspiration
+
 Here are some resources whose ideas resonate with me and have informed this library.
 
-- Jeremy Wagner's writing on [Lazy Loading Images and Video](https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video/) is a good reference for the problem and solutions space.
+* Jeremy Wagner's writing on [Lazy Loading Images and Video](https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video/) is a good reference for the problem and solutions space.
 
-- The library backing this one, [react-intersection-observer](https://github.com/thebuilder/react-intersection-observer).
-Further thanks for demonstrating Storybook as documentation for lazy-loading.
+* The library backing this one, [react-intersection-observer](https://github.com/thebuilder/react-intersection-observer).
+  Further thanks for demonstrating Storybook as documentation for lazy-loading.
 
-- [José M. Pérez has a good resource on lazy loading](https://jmperezperez.com/high-performance-lazy-loading/)
+* [José M. Pérez has a good resource on lazy loading](https://jmperezperez.com/high-performance-lazy-loading/)
 
-- [Paul Lewis' implementation of lazy image loading](https://github.com/GoogleChromeLabs/sample-media-pwa/blob/master/src/client/scripts/helpers/lazy-load-images.js) has the concept of pre-loading images before swapping.
+* [Paul Lewis' implementation of lazy image loading](https://github.com/GoogleChromeLabs/sample-media-pwa/blob/master/src/client/scripts/helpers/lazy-load-images.js) has the concept of pre-loading images before swapping.
 
-- [Dave Rupert has a good guide on intrinsic image placeholders](https://daverupert.com/2015/12/intrinsic-placeholders-with-picture/)
+* [Dave Rupert has a good guide on intrinsic image placeholders](https://daverupert.com/2015/12/intrinsic-placeholders-with-picture/)
 
 ## License
 

--- a/src/LazyImage.tsx
+++ b/src/LazyImage.tsx
@@ -45,21 +45,23 @@ export const LazyImage: React.StatelessComponent<LazyImageProps> = ({
   ...rest
 }) => (
   <LazyImageFull {...rest}>
-    {({src, srcSet, imageState}) => {
+    {({src, srcSet, alt, imageState}) => {
+      // Call the appropriate render callback based on the state
+      // and the props specified, passing on relevant props.
       switch (imageState) {
         case ImageState.NotAsked:
           return !!placeholder && placeholder({alt});
 
         case ImageState.Loading:
           // Only render loading if specified, otherwise placeholder
-          return !!loading ? loading() : !!placeholder && placeholder();
+          return !!loading ? loading() : !!placeholder && placeholder({alt});
 
         case ImageState.LoadSuccess:
           return actual({src, alt, srcSet});
 
         case ImageState.LoadError:
           // Only render error if specified, otherwise actual (broken image)
-          return !!error ? error() : actual();
+          return !!error ? error() : actual({src, alt, srcSet});
       }
     }}
   </LazyImageFull>

--- a/src/LazyImage.tsx
+++ b/src/LazyImage.tsx
@@ -4,14 +4,22 @@ import {LazyImageFull, CommonLazyImageProps, ImageState} from './LazyImageFull';
 /**
  * Valid props for LazyImage
  */
+export interface LazyImageRenderPropArgs {
+  src?: string;
+  srcSet?: string;
+  alt?: string;
+}
+
 export interface LazyImageProps extends CommonLazyImageProps {
   /** Component to display once image has loaded */
-  actual: () => React.ReactElement<{}>;
+  actual: (args: LazyImageRenderPropArgs) => React.ReactElement<{}>;
 
   /** Component to display while image has not been requested
    * @default: undefined
    */
-  placeholder?: () => React.ReactElement<{}>;
+  placeholder?: (
+    args: Pick<LazyImageRenderPropArgs, 'alt'>
+  ) => React.ReactElement<{}>;
 
   /** Component to display while the image is loading
    * @default placeholder, if defined
@@ -40,17 +48,17 @@ export const LazyImage: React.StatelessComponent<LazyImageProps> = ({
     {({src, srcSet, imageState}) => {
       switch (imageState) {
         case ImageState.NotAsked:
-          return !!placeholder && placeholder();
+          return !!placeholder && placeholder({alt});
 
         case ImageState.Loading:
           // Only render loading if specified, otherwise placeholder
           return !!loading ? loading() : !!placeholder && placeholder();
 
         case ImageState.LoadSuccess:
-          return actual();
+          return actual({src, alt, srcSet});
 
         case ImageState.LoadError:
-          // Only render error if specified, otherwise actual
+          // Only render error if specified, otherwise actual (broken image)
           return !!error ? error() : actual();
       }
     }}

--- a/src/LazyImageFull.tsx
+++ b/src/LazyImageFull.tsx
@@ -11,6 +11,9 @@ export interface CommonLazyImageProps {
   /** The source set of the image to load */
   srcSet?: string;
 
+  /** The alt text description of the image you are loading */
+  alt?: string;
+
   /** Whether to skip checking for viewport and always show the 'actual' component
    * @see https://github.com/fpapado/react-lazy-images/#eager-loading--server-side-rendering-ssr
    */
@@ -35,7 +38,7 @@ export interface LazyImageFullProps extends CommonLazyImageProps {
 
 /** Values that the render props take */
 export interface LazyImageFullRenderPropArgs {
-  state: ImageState;
+  imageState: ImageState;
   src?: string;
   srcSet?: string;
   alt?: string;

--- a/stories/LazyImage.story.tsx
+++ b/stories/LazyImage.story.tsx
@@ -5,6 +5,8 @@ import {withInfo} from '@storybook/addon-info';
 import {LazyImage} from '../src/index';
 import {Container} from './utils';
 
+// Helpers to save typing. You can imagine that in
+// some cases, you too will have more specific components.
 const PlaceholderImage = () => (
   <img
     src="img/porto_buildings_lowres.jpg"
@@ -34,8 +36,14 @@ stories
       <Container>
         <LazyImage
           src="img/porto_buildings_large.jpg"
-          placeholder={() => <PlaceholderImage />}
-          actual={() => <ActualImage />}
+          placeholder={({alt}) => (
+            <img
+              src="img/porto_buildings_lowres.jpg"
+              alt={alt}
+              className="w-100"
+            />
+          )}
+          actual={({src, alt}) => <img src={src} alt={alt} className="w-100" />}
         />
       </Container>
     ))
@@ -50,42 +58,22 @@ stories
         <LazyImage
           src="https://www.fillmurray.com/g/300/200"
           srcSet="https://www.fillmurray.com/g/900/600 900w, https://www.fillmurray.com/g/600/400 600w, https://www.fillmurray.com/g/300/200 300w"
-          placeholder={() => (
+          alt="A portrait of Bill Murray."
+          placeholder={({alt}) => (
             <img
               src="https://www.fillmurray.com/g/60/40"
+              alt={alt}
               className="w-100"
-              alt="A portrait of Bill Murray."
             />
           )}
-          actual={() => (
-            <img
-              src="https://www.fillmurray.com/g/300/200"
-              srcSet="https://www.fillmurray.com/g/900/600 900w, https://www.fillmurray.com/g/600/400 600w, https://www.fillmurray.com/g/300/200 300w"
-              className="w-100"
-              alt="A portrait of Bill Murray."
-            />
+          actual={({src, srcSet, alt}) => (
+            <img src={src} srcSet={srcSet} alt={alt} className="w-100" />
           )}
         />
       </Container>
     ))
   )
-  // Without preloading
-  /*
-  .add(
-    'Without preloading (no src or srcSet)',
-    withInfo(
-      'Sometimes, it might be impractical to specify the src with your current setup. For example, it is possible that you are generating the sources for an Image CDN and have a dedicated component for it. In those cases, changing the component might be impractical in the short-term. If you provide no src or srcSet, then the preload-before-swap behaviour is not used. We believe that showing a possibly still-downloading image is better than having lazy-loading at all.'
-    )(() => (
-      <Container>
-        <LazyImage
-          placeholder={() => <PlaceholderImage />}
-          actual={() => <ActualImage />}
-        />
-      </Container>
-    ))
-  )
-  */
-  // Always load an image (aka "eagerly"; how the browser does it already.
+  // Always load an image ("eagerly"; how the browser does it already.
   // Useful if you want to load the actual content without waiting for Javascript.
   .add(
     'Eager loading (Server-Side Rendering)',
@@ -119,19 +107,16 @@ stories
             loadEagerly={i === 0}
             key={key}
             src={`https://www.fillmurray.com/g/${actual}`}
-            placeholder={() => (
+            alt="A portrait of Bill Murray."
+            placeholder={({alt}) => (
               <img
                 src={`https://www.fillmurray.com/g/${placeholder}`}
+                alt={alt}
                 className="w-100"
-                alt="A portrait of Bill Murray."
               />
             )}
-            actual={() => (
-              <img
-                src={`https://www.fillmurray.com/g/${actual}`}
-                className="w-100"
-                alt="A portrait of Bill Murray."
-              />
+            actual={({src, alt}) => (
+              <img src={src} alt={alt} className="w-100" />
             )}
           />
         ))}
@@ -167,7 +152,7 @@ stories
           <LazyImage
             src="https://www.fillmurray.com/notanimage"
             placeholder={() => <div />}
-            actual={() => <img src="https://www.fillmurray.com/notanimage" />}
+            actual={({src}) => <img src={src} />}
             loading={() => (
               <div>
                 <p className="pa3 f5 lh-copy near-white">Loading...</p>
@@ -200,17 +185,16 @@ stories
               <LazyImage
                 key={key}
                 src={`https://www.fillmurray.com/g/${actual}`}
-                placeholder={() => (
+                alt="A portrait of Bill Murray."
+                placeholder={({alt}) => (
                   <img
                     src={`https://www.fillmurray.com/g/${placeholder}`}
+                    alt={alt}
                     className="w-100"
                   />
                 )}
-                actual={() => (
-                  <img
-                    src={`https://www.fillmurray.com/g/${actual}`}
-                    className="w-100"
-                  />
+                actual={({src, alt}) => (
+                  <img src={src} alt={alt} className="w-100" />
                 )}
               />
             </div>
@@ -237,7 +221,7 @@ stories
             placeholder={() => (
               <BgImage bgSrc="img/porto_buildings_lowres.jpg" />
             )}
-            actual={() => <BgImage bgSrc="img/porto_buildings_large.jpg" />}
+            actual={({src}) => <BgImage bgSrc={src} />}
           />
         </Container>
       );

--- a/stories/LazyImage.story.tsx
+++ b/stories/LazyImage.story.tsx
@@ -36,6 +36,7 @@ stories
       <Container>
         <LazyImage
           src="img/porto_buildings_large.jpg"
+          alt="Buildings with tiled exteriors, lit by the sunset."
           placeholder={({alt}) => (
             <img
               src="img/porto_buildings_lowres.jpg"

--- a/stories/LazyImageFull.story.tsx
+++ b/stories/LazyImageFull.story.tsx
@@ -18,15 +18,18 @@ stories
     Anything you can implement with LazyImage, you can implement with LazyImageFull.`
     )(() => (
       <Container>
-        <LazyImageFull src="img/porto_buildings_large.jpg">
-          {({imageState, src}) => (
+        <LazyImageFull
+          src="img/porto_buildings_large.jpg"
+          alt="Buildings with tiled exteriors, lit by the sunset."
+        >
+          {({imageState, src, alt}) => (
             <img
               src={
                 imageState === ImageState.LoadSuccess
                   ? src
                   : 'img/porto_buildings_lowres.jpg'
               }
-              alt="Buildings with tiled exteriors, lit by the sunset."
+              alt={alt}
               className="w-100"
             />
           )}
@@ -40,14 +43,15 @@ stories
       <Container>
         <LazyImageFull
           src="img/porto_buildings_large.jpg"
-          render={({imageState, src}) => (
+          alt="Buildings with tiled exteriors, lit by the sunset."
+          render={({imageState, src, alt}) => (
             <img
               src={
                 imageState === ImageState.LoadSuccess
                   ? src
                   : 'img/porto_buildings_lowres.jpg'
               }
-              alt="Buildings with tiled exteriors, lit by the sunset."
+              alt={alt}
               className="w-100"
             />
           )}


### PR DESCRIPTION
This PR changes the `actual` and `placeholder` render callbacks for `LazyImage` to pass back `src`, `srcSet`. The `alt` attribute is now accepted at the top level, both in `LazyImage` and `LazyImageFull`, and passed in the respective callbacks.

The motivation for this is that in most cases, the user will eventually be rendering an `img` with those attributes. While they can still be passed through closures/manually, they are prone to repetition/typing/(in)consistency mistakes (I know I've made those when writing `stories/`). Mismatching `src` or `srcSet` discards the benefits of preloading, and mismatching `alt` harms accessibility.

Thus, to encourage correct use, they are passed in the render callbacks and shown as such in the examples. As with all render prop APIs, the user can ignore them (by just not passing them to the components) but presumably they would have a good reason to do so, and it is now harder to do accidentally.

Many thanks to Marcy Sutton in issue #1 for pointing out the accessibility concerns, and helping flesh this out.