### PR TITLE
expose margin and threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ Any of the presentational patterns presented that are possible with `LazyImage` 
 
 In fact, if you check [`src/LazyImage.tsx`](./src/LazyImage.tsx), you will see that `LazyImage` is implemented in terms of `LazyImageFull`!
 
+### Load ahead and threshold
+
+There are two optional props on both `LazyImageFull` and `LazyImage`, which gice you more control as to when your Images are requested.
+
+`rootMargin`: Margin around the window. This can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left)
+This can provide control if you want to request your image a certain number of pixels ahead of where the user is scrolling.
+
+`threshold`: Number between 0 and 1 indicating the percentage that should be visible before a request is sent.
+
 ### Load before swap
 
 A common optimisation to the loading strategy is to preload the image before swapping it for the placeholder.

--- a/README.md
+++ b/README.md
@@ -211,12 +211,29 @@ In fact, if you check [`src/LazyImage.tsx`](./src/LazyImage.tsx), you will see t
 
 ### Load ahead and threshold
 
-There are two optional props on both `LazyImageFull` and `LazyImage`, which gice you more control as to when your Images are requested.
+Further control over the Intersection Observer can be provided through the `observerProps` prop object:
 
-`rootMargin`: Margin around the window. This can have values similar to the CSS margin property, e.g. "10px 20px 30px 40px" (top, right, bottom, left)
+```jsx
+import { LazyImage } from "react-lazy-images";
+
+<LazyImage
+  src="/img/porto_buildings_large.jpg"
+  alt="Buildings with tiled exteriors, lit by the sunset."
+  placeholder={/* the usual */}
+  actual={/* the usual */}
+  observerProps={{
+    rootMargin: "100px 0",
+    threshold: 0.3
+  }}
+/>;
+```
+
+`rootMargin`: Margin around the window. This can have values similar to the CSS margin property, e.g. `"10px 20px 30px 40px"` (top, right, bottom, left) (defaulted to `"50px 0px"`)
 This can provide control if you want to request your image a certain number of pixels ahead of where the user is scrolling.
 
-`threshold`: Number between 0 and 1 indicating the percentage that should be visible before a request is sent.
+`threshold`: Number between 0 and 1 indicating the percentage that should be visible before a request is sent. (defaulted to `0.01`)
+
+(See https://github.com/thebuilder/react-intersection-observer#api)
 
 ### Load before swap
 

--- a/src/LazyImageFull.tsx
+++ b/src/LazyImageFull.tsx
@@ -35,6 +35,17 @@ export type CommonLazyImageProps = ImageProps & {
    * TODO: naming things.
    */
   debounceDurationMs?: number;
+
+  /** Set the margins for intersection observer:
+   * Allows preloading of content, works similarly to CSS margin
+   */
+  rootMargin?: string;
+
+  /** Set the threshold for intersection observer:
+   * Number between 0 and 1 indicating the percentage that should be visible before triggering.
+   *Can also be an array of numbers, to create multiple trigger points
+   */
+  threshold?: number | number[];
 };
 
 /** Valid props for LazyImageFull */
@@ -330,11 +341,12 @@ export class LazyImageFull extends React.Component<
         imageProps
       });
     } else {
+      const { rootMargin = "50px 0px", threshold = 0.01 } = this.props;
       return (
         <Observer
-          rootMargin="50px 0px"
+          rootMargin={rootMargin}
           // TODO: reconsider threshold
-          threshold={0.01}
+          threshold={threshold}
           {...observerProps}
           onChange={inView => this.update(Action.ViewChanged({ inView }))}
         >

--- a/src/LazyImageFull.tsx
+++ b/src/LazyImageFull.tsx
@@ -35,17 +35,6 @@ export type CommonLazyImageProps = ImageProps & {
    * TODO: naming things.
    */
   debounceDurationMs?: number;
-
-  /** Set the margins for intersection observer:
-   * Allows preloading of content, works similarly to CSS margin
-   */
-  rootMargin?: string;
-
-  /** Set the threshold for intersection observer:
-   * Number between 0 and 1 indicating the percentage that should be visible before triggering.
-   *Can also be an array of numbers, to create multiple trigger points
-   */
-  threshold?: number | number[];
 };
 
 /** Valid props for LazyImageFull */
@@ -341,12 +330,11 @@ export class LazyImageFull extends React.Component<
         imageProps
       });
     } else {
-      const { rootMargin = "50px 0px", threshold = 0.01 } = this.props;
       return (
         <Observer
-          rootMargin={rootMargin}
+          rootMargin={"50px 0px"}
           // TODO: reconsider threshold
-          threshold={threshold}
+          threshold={0.01}
           {...observerProps}
           onChange={inView => this.update(Action.ViewChanged({ inView }))}
         >

--- a/src/LazyImageFull.tsx
+++ b/src/LazyImageFull.tsx
@@ -332,7 +332,7 @@ export class LazyImageFull extends React.Component<
     } else {
       return (
         <Observer
-          rootMargin={"50px 0px"}
+          rootMargin="50px 0px"
           // TODO: reconsider threshold
           threshold={0.01}
           {...observerProps}


### PR DESCRIPTION
I am proposing to expose the margin and threshold as optional props for LazyImages.

This will allow users to use the margin for "load ahead" in scrolling, and allow them to set a threshold to their liking. 