### PR TITLE
Fix syntax highlight in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This behaviour is provided with the `src` prop:
   alt="Buildings with tiled exteriors, lit by the sunset."
   placeholder={
     ({imageProps, ref}) =>
-      <div ref={ref} className={`LazyImage-Placeholder`}">
+      <div ref={ref} className={`LazyImage-Placeholder`}>
         <img src="/img/porto_buildings_lowres.jpg" alt={imageProps.alt} />
       </div>
   }


### PR DESCRIPTION
The extra double quote is breaking the code syntax highlighting in the section below