### PR TITLE
Stop passing events to Promise.reject

### DIFF
--- a/src/LazyImageFull.tsx
+++ b/src/LazyImageFull.tsx
@@ -390,7 +390,7 @@ const loadImage = (
     }
 
     image.onload = resolve;
-    image.onerror = reject;
+    image.onerror = event => reject(new Error(`Failed to load: ${src}`));
   });
 
 /** Promise that resolves after a specified number of ms */


### PR DESCRIPTION
image.onerror is passed an event, not an error:
https://github.com/getsentry/sentry-javascript/issues/2546#issuecomment-703331367
https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement

Passing reject directly to onerror causes the event to be thrown instead of an error:
https://github.com/getsentry/sentry-javascript/issues/2546