### PR TITLE
fix(lazy-image): replace deprecated type

### DIFF
--- a/src/LazyImage.tsx
+++ b/src/LazyImage.tsx
@@ -45,7 +45,7 @@ export interface LazyImageProps extends CommonLazyImageProps {
  * and then swaps it in. Has predefined rendering logic, but the
  * specifics are up to the caller.
  */
-export const LazyImage: React.StatelessComponent<LazyImageProps> = ({
+export const LazyImage: React.FC<LazyImageProps> = ({
   actual,
   placeholder,
   loading,


### PR DESCRIPTION
It just replaces the depreacted `StatelessFunction` in favor of `FC` / `FunctionComponent`